### PR TITLE
Use `Object.create(null)` to avoid inherit properties like `constructor`

### DIFF
--- a/src/lexicon.ts
+++ b/src/lexicon.ts
@@ -2,7 +2,7 @@ export interface LexiconType {
   [key:string]:string
 }
 
-const lexicon = <LexiconType> {
+const lexicon = <LexiconType> Object.assign(Object.create(null), {
   "!": "!",
   "#": "#",
   "...": ":",
@@ -111980,6 +111980,6 @@ const lexicon = <LexiconType> {
   "🇾🇪": "EM",
   "🇿🇲": "EM",
   "🇿🇼": "EM"
-}
+});
 
 export default lexicon;


### PR DESCRIPTION
Objects created from literal syntax will inherit properties from
`Object.prototype`, which includes `constructor`.
As a result, `lexcon['constructor']` will return a function object
instead of undefined.

This bug was discovered while using `en-pos`, and can be reproduced by the following code:
```js
const Tag = require("en-pos").Tag;
const tags = new Tag(["constructor"]).initial() .smooth().tags;
```
During `initial()`, it calls [lexicon.ts](https://github.com/FinNLP/en-pos/blob/master/src/tagging/lexicon.ts) where it assumes the return value of `lexicon[token]` is either `undefined` or `string`.